### PR TITLE
adding tag _jsonparsefailure for failures in json_lines-codecs

### DIFF
--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -37,7 +37,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
         yield LogStash::Event.new(LogStash::Json.load(event["message"]))
       rescue LogStash::Json::ParserError => e
         @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => data)
-        yield LogStash::Event.new("message" => event["message"])
+        yield LogStash::Event.new("message" => event["message"], "tags" => "_jsonparsefailure")
       end
     end
   end # def decode

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -39,6 +39,7 @@ describe LogStash::Codecs::JSONLines do
           decoded = true
           insist { event.is_a?(LogStash::Event) }
           insist { event["message"] } == "something that isn't json"
+          insist { event["tags"] }.include?("_jsonparsefailure")
         end
         insist { decoded } == true
       end


### PR DESCRIPTION
@mluebcke
Logstash moved plugins to their own repositories.

moved PR from: https://github.com/elasticsearch/logstash/pull/1091