### PR TITLE
make "tags" to be array like "tags" in grok filter

### DIFF
--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -37,7 +37,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
         yield LogStash::Event.new(LogStash::Json.load(event["message"]))
       rescue LogStash::Json::ParserError => e
         @logger.info("JSON parse failure. Falling back to plain-text", :error => e, :data => data)
-        yield LogStash::Event.new("message" => event["message"], "tags" => "_jsonparsefailure")
+        yield LogStash::Event.new("message" => event["message"], "tags" => ["_jsonparsefailure"])
       end
     end
   end # def decode

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -58,6 +58,31 @@ describe LogStash::Codecs::JSONLines do
         insist { decoded } == true
       end
     end
+
+    context "when json could not be parsed" do
+
+      let(:message)    { "random_message\n" }
+
+      it "add the failure tag" do
+        subject.decode(message) do |event|
+          expect(event).to include "tags"
+        end
+      end
+
+      it "uses an array to store the tags" do
+        subject.decode(message) do |event|
+          expect(event['tags']).to be_a Array
+        end
+      end
+
+      it "add a json parser failure tag" do
+        subject.decode(message) do |event|
+          expect(event['tags']).to include "_jsonparsefailure"
+        end
+      end
+
+    end
+
   end
 
   context "#encode" do


### PR DESCRIPTION
This pull request will make json filter to be the same as "tags" in grok filter, which fix this situation:
```
{
     "tags" => "_jsonparsefailure_grokparsefailure",
     "@version" => "1",
     "@timestamp" => "2015-04-13T09:06:48.887Z",
     ...
}
```

if _jsonparsefailure and _grokparsefailure occur in the same time , the correct output will be:
```
{
     "tags" => [
         [0] "_jsonparsefailure",
         [1] "_grokparsefailure"
     ],
     "@version" => "1",
     "@timestamp" => "2015-04-13T09:06:48.887Z",
     ...
}
```