### PR TITLE
enable the configuration of the line delimiter for the json output

### DIFF
--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -21,7 +21,8 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
   #
   # For nxlog users, you'll want to set this to `CP1252`
   config :charset, :validate => ::Encoding.name_list, :default => "UTF-8"
-
+  config :line_delimiter, :validate => :number
+  
   public
   def initialize(params={})
     super(params)
@@ -46,7 +47,11 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
   def encode(event)
     # Tack on a \n for now because previously most of logstash's JSON
     # outputs emitted one per line, and whitespace is OK in json.
-    @on_event.call(event, event.to_json + NL)
+    if @line_delimiter != nil
+      @on_event.call(event, event.to_json + @line_delimiter.chr)
+    else
+      @on_event.call(event, event.to_json + NL)
+    end 
   end # def encode
 
 end # class LogStash::Codecs::JSON


### PR DESCRIPTION
Hi,

I tried to ship messages to a graylog gelf server over the TCP GELF input. Unfortunately it didn't work because Graylog did not accept the messages logstash was sending, both with NUL delimiters and \n delimiters. Might be a bug in graylog-inputs, not sure.
So I tried to patch the logstash codec and it worked like a charm.
You can now do something like this to use `\0` as delimiter:

``` ruby
tcp {
    codec => json_lines {
            line_delimiter => 0
        }
    }
}
```

I'm not a ruby star so there might be many better ways to do it.
Can you please take a look at it and eventually merge it or provide a similar functionality.
Thank you!

Max
