### PR TITLE
set timestamp to avoid delta in double timestamp initialization

### DIFF
--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -82,12 +82,11 @@ describe LogStash::Codecs::JSONLines do
       end
 
     end
-
   end
 
   context "#encode" do
     it "should return json data" do
-      data = {"foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
+      data = {LogStash::Event::TIMESTAMP => "2015-12-07T11:37:00.000Z", "foo" => "bar", "baz" => {"bah" => ["a","b","c"]}}
       event = LogStash::Event.new(data)
       got_event = false
       subject.on_event do |e, d|


### PR DESCRIPTION
the Java Timestamp has millisec resolution and the spec compares two Event initialized in sequence and originally it was relying on using a new timestamp thus using 2 slightly difference times. This fix simply hardcodes the timestamp which does not change the spec requirements.

relates to elastic/logstash#4264 and elastic/logstash#4191