### PR TITLE
directly use buftok to avoid indirection through the line codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+ - Directly use buftok to avoid indirection through the line codec https://github.com/logstash-plugins/logstash-codec-json_lines/pull/18
+
 ## 2.0.4
  - Support for customizable delimiter
 

--- a/logstash-codec-json_lines.gemspec
+++ b/logstash-codec-json_lines.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json_lines'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec will decode streamed JSON that is newline delimited."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','spec/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "logstash/codecs/json_lines"
 require "logstash/event"
 require "logstash/json"


### PR DESCRIPTION
as discussed in #17 

this does not solve the flushing issue raised. we can either create a new PR for it or include that fix here. 