### PR TITLE
ignore blank/empty json lines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+gem "logstash-core", :path => "/Users/colin/dev/src/elasticsearch/logstash/logstash-core"
+gem "logstash-core-event-java", :path => "/Users/colin/dev/src/elasticsearch/logstash/logstash-core-event-java"

--- a/logstash-codec-json_lines.gemspec
+++ b/logstash-codec-json_lines.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json_lines'
-  s.version         = '2.1.0'
+  s.version         = '2.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This codec will decode streamed JSON that is newline delimited."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -78,7 +78,6 @@ describe LogStash::Codecs::JSONLines do
     end
 
     context "when json could not be parsed" do
-
       let(:message)    { "random_message\n" }
 
       it "add the failure tag" do
@@ -98,8 +97,26 @@ describe LogStash::Codecs::JSONLines do
           expect(event['tags']).to include "_jsonparsefailure"
         end
       end
-
     end
+
+    context "blank lines" do
+      let(:collector) { Array.new }
+
+      it "should ignore bare blanks" do
+        subject.decode("\n\n") do |event|
+          collector.push(event)
+        end
+        expect(collector.size).to eq(0)
+      end
+
+      it "should ignore in between blank lines" do
+        subject.decode("\n{\"a\":1}\n\n{\"b\":2}\n\n") do |event|
+          collector.push(event)
+        end
+        expect(collector.size).to eq(2)
+      end
+    end
+
   end
 
   context "#encode" do


### PR DESCRIPTION
replaces #2 
fixes #5
fixes elastic/logstash#4618

logstash Event PR elastic/logstash/pull/4671 is required to support the same behaviour in the Event#from_json method for 2.3+