### PR TITLE
make sure the devutils rspec helpers are loader before

### DIFF
--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/json_lines"
 require "logstash/event"
 require "logstash/json"


### PR DESCRIPTION
Make sure the devutils rspec helpers are loaded before any tests to make
sure the log4j classes are correctly configured.

Fixes: #32

