### PR TITLE
add flush support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+  - Support flush method, see https://github.com/logstash-plugins/logstash-codec-json_lines/pull/35
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -48,6 +48,13 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
     @on_event.call(event, "#{event.to_json}#{@delimiter}")
   end
 
+  def flush(&block)
+    remainder = @buffer.flush
+    if !remainder.empty?
+      parse(@converter.convert(remainder), &block)
+    end
+  end
+
   private
 
   # from_json_parse uses the Event#from_json method to deserialize and directly produce events

--- a/logstash-codec-json_lines.gemspec
+++ b/logstash-codec-json_lines.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json_lines'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads and writes newline-delimited JSON"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -214,5 +214,24 @@ describe LogStash::Codecs::JSONLines do
         LogStash::Codecs::JSONLines.new(codec_options)
       end
     end
+
+    context "flush" do
+      subject do
+        LogStash::Codecs::JSONLines.new(codec_options)
+      end
+
+      let(:input) { "{\"foo\":\"bar\"}" }
+
+      it "should flush buffered data'" do
+        result = []
+        subject.decode(input) { |e| result << e }
+        expect(result.size).to eq(0)
+
+        subject.flush { |e| result << e }
+        expect(result.size).to eq(1)
+
+        expect(result[0].get("foo")).to eq("bar")
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #20 and it also fixes the issue with inputs like http where each received payload will always yield one or many json lines but may not contain a delimiter on the last one. These inputs need to call flush after each request to make sure any buffers are emptied. 

This codec will now be consistent with the line codec which also support the flush method in the same way.

Also, for reference, this flush "semantic" was discussed in elastic/logstash#8830
