### PR TITLE
Re-established previous behaviour without a default limit for 'decode_size_limit_bytes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.3
+  - Update behaviour of `decode_size_limit_bytes` to do not apply any limitation to the length of a line, eventually tagging the event if it's set. [#45](https://github.com/logstash-plugins/logstash-codec-json_lines/pull/45)
+
 ## 3.2.2
   - Fix: updated the way to check if the `decode_size_limit_bytes` has been explicitly customised. [#47](https://github.com/logstash-plugins/logstash-codec-json_lines/pull/47)
 

--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -61,6 +61,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
       deprecation_logger.deprecated "The default value for `decode_size_limit_bytes`, currently at 512MB, will be lowered in a future version to prevent Out of Memory errors from abnormally large messages or missing delimiters. Please set a value that reflects the largest expected message size (e.g. 20971520 for 20MB)"
     end
     @buffer = FileWatch::BufferedTokenizer.new(@delimiter, @decode_size_limit_bytes)
+    puts "DNADBG>> delimiter is [#{@delimiter}]"
     @converter = LogStash::Util::Charset.new(@charset)
     @converter.logger = @logger
   end
@@ -71,7 +72,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
     end
   rescue java.lang.IllegalStateException => e
     if e.message == "input buffer full" && @decode_size_limit_bytes != "none"
-      yield event_factory.new_event("message" => data[0..@decode_size_limit_bytes.to_i - 1], "tags" => ["_jsonparsetoobigfailure"]) #TODO check the failure tag
+      yield event_factory.new_event("message" => "Payload bigger than #{@decode_size_limit_bytes} bytes", "tags" => ["_jsonparsetoobigfailure"])
     else
       # re-raise the error if doesn't correspond to the buffer overflow condition
       raise e

--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -70,7 +70,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
       parse_json(@converter.convert(line), &block)
     end
   rescue java.lang.IllegalStateException => e
-    if e.message == "input buffer full" && @decode_size_limit_bytes != "none"
+    if /^input buffer full/ =~ e.message && @decode_size_limit_bytes != "none"
       yield event_factory.new_event("message" => "Payload bigger than #{@decode_size_limit_bytes} bytes", "tags" => ["_jsonparsetoobigfailure"])
     else
       # re-raise the error if doesn't correspond to the buffer overflow condition

--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -61,7 +61,6 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
       deprecation_logger.deprecated "The default value for `decode_size_limit_bytes`, currently at 512MB, will be lowered in a future version to prevent Out of Memory errors from abnormally large messages or missing delimiters. Please set a value that reflects the largest expected message size (e.g. 20971520 for 20MB)"
     end
     @buffer = FileWatch::BufferedTokenizer.new(@delimiter, @decode_size_limit_bytes)
-    puts "DNADBG>> delimiter is [#{@delimiter}]"
     @converter = LogStash::Util::Charset.new(@charset)
     @converter.logger = @logger
   end

--- a/logstash-codec-json_lines.gemspec
+++ b/logstash-codec-json_lines.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-json_lines'
-  s.version         = '3.2.2'
+  s.version         = '3.2.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads and writes newline-delimited JSON"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -130,6 +130,13 @@ describe LogStash::Codecs::JSONLines, :ecs_compatibility_support do
 
       it "should raise an error if the max bytes are exceeded" do
         subject.decode(maximum_payload << "z") do |event|
+          expect(event.get("tags")).to include("_jsonparsetoobigfailure")
+          expect(event.get("message").size).to eq(decode_size_limit_bytes)
+        end
+      end
+
+      it "should raise an error if the max bytes are exceeded" do
+        subject.decode(maximum_payload << "z") do |event|
           expect(event.get("tags")).to include("_jsonparse_too_big_failure")
           expect(event.get("message").size).to eq(decode_size_limit_bytes)
         end

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -127,6 +127,13 @@ describe LogStash::Codecs::JSONLines, :ecs_compatibility_support do
           subject.decode(maximum_payload)
         }.not_to raise_error
       end
+
+      it "should raise an error if the max bytes are exceeded" do
+        subject.decode(maximum_payload << "z") do |event|
+          expect(event.get("tags")).to include("_jsonparse_too_big_failure")
+          expect(event.get("message").size).to eq(decode_size_limit_bytes)
+        end
+      end
       
       it "should raise an error if the max bytes are exceeded" do
         expect {

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -134,12 +134,6 @@ describe LogStash::Codecs::JSONLines, :ecs_compatibility_support do
           expect(event.get("message")).to eq("Payload bigger than #{subject.decode_size_limit_bytes} bytes")
         end
       end
-
-      it "should raise an error if the max bytes are exceeded" do
-        expect {
-          subject.decode(maximum_payload << "z")
-        }.to raise_error(java.lang.IllegalStateException, "input buffer full")
-      end
     end
 
   end

--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -131,17 +131,10 @@ describe LogStash::Codecs::JSONLines, :ecs_compatibility_support do
       it "should raise an error if the max bytes are exceeded" do
         subject.decode(maximum_payload << "z") do |event|
           expect(event.get("tags")).to include("_jsonparsetoobigfailure")
-          expect(event.get("message").size).to eq(decode_size_limit_bytes)
+          expect(event.get("message")).to eq("Payload bigger than #{subject.decode_size_limit_bytes} bytes")
         end
       end
 
-      it "should raise an error if the max bytes are exceeded" do
-        subject.decode(maximum_payload << "z") do |event|
-          expect(event.get("tags")).to include("_jsonparse_too_big_failure")
-          expect(event.get("message").size).to eq(decode_size_limit_bytes)
-        end
-      end
-      
       it "should raise an error if the max bytes are exceeded" do
         expect {
           subject.decode(maximum_payload << "z")


### PR DESCRIPTION
## Release notes
Update behaviour of `decode_size_limit_bytes` to do not apply any limitation to the length of a line, eventually tagging the event if it's set.


## What does this PR do?

If `decode_size_limit_bytes` is unset re-establish the behaviour like before version `3.2.0` so that if a long line, close to the heap available space, is processed by the codec then it would throw an OOM and kill Logstash. If the such config is instead explicitly set then instead of continue looping with a warning log, it still produces an event but it's tagged with an error and the content of the message clipped at the first `decode_size_limit_bytes` bytes.


## Why is it important/What is the impact to the user?

With #43 which configured a default 20Mb limit on the size of the line to parse, it introduced a breaking change in the behaviour of existing installations. If a Logstash was parsing correctly lines wide 30Mb, then after that change it would encounter an error.
With this PR the existing behaviour is re-established but let the use to explicitly set a limit that once passed, instead of make a continuous iteration on the error, still produces an event but it's tagger with error and contains a slice of the offending input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] do a real test with same setup as described in #43 

## How to test this PR locally

- Use a pipelines with the codec that limit at 512 bytes, such as:
```
input {
  stdin {
    codec => json_lines {
      decode_size_limit_bytes => 512
    }  
  }
}

output {
  stdout {
    codec => rubydebug
  }
}
```
- very that generates a an event tagging it with the `_jsonparsetoobigfailure` and a `message` clipped at 512, as sample file you  can use 
[1kb_single_line.json](https://github.com/user-attachments/files/16837686/1kb_single_line.json)
- launch Logstash like
```sh
cat /path/to/1kb_single_line.json | bin/logstash -f /path/to/test_pipeline.conf
```

## Related issues

- Closes #44 


## Logs

```
[2024-09-02T14:45:51,796][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id"=>"main"}
{
    "@timestamp" => 2024-09-02T12:45:51.801192Z,
         "event" => {
        "original" => "{\"field_1\": [{\"name\":\"Jannik\",\"surname\":\"Sinner\"},{\"name\":\"Novak\",\"surname\":\"Djokovic\"},{\"name\":\"Rafa\",\"surname\":\"Nadal\"},{\"name\":\"Roger\",\"surname\":\"Federer\"},{\"name\":\"Pete\",\"surname\":\"Sampras\"},{\"name\":\"Andr\xC3\xA9\",\"surname\":\"Agassi\"},{\"name\":\"Rod\",\"surname\":\"Laver\"},{\"name\":\"Ivan\",\"surname\":\"Lendl\"},{\"name\":\"Bjorn\",\"surname\":\"Borg\"},{\"name\":\"John\",\"surname\":\"McEnroe\"},{\"name\":\"Jimmy\",\"surname\":\"Connors\"}],\"field_2\": [{\"name\":\"Jannik\",\"surname\":\"Sinner\"},{\"name\":\"Novak\",\"surname\":\"Djokovic\"},{\"name\":\"Rafa\",\"surname\":\"Nadal\"},{\"name\":\"Roger\",\"surname\":\"Federer\"},{\"name\":\"Pete\",\"surname\":\"Sampras\"},{\"name\":\"Andr\xC3\xA9\",\"surname\":\"Agassi\"},{\"name\":\"Rod\",\"surname\":\"Laver\"},{\"name\":\"Ivan\",\"surname\":\"Lendl\"},{\"name\":\"Bjorn\",\"surname\":\"Borg\"},{\"name\":\"John\",\"surname\":\"McEnroe\"},{\"name\":\"Jimmy\",\"surname\":\"Connors\"}],\"field_3\": [{\"name\":\"Jannik\",\"surname\":\"Sinner\"},{\"name\":\"Novak\",\"surname\":\"Djokovic\"},{\"name\":\"Rafa\",\"surname\":\"Nadal\"},{\"name\":\"Roger\",\"surname\":\"Federer\"},{\"name\":\"Pete\",\"surname\":\"Sampras\"},{\"name\":\"Andr\xC3\xA9\",\"surname\":\"Agassi\"},{\"name\":\"Rod\",\"surname\":\"Laver\"},{\"name\":\"Ivan\",\"surname\":\"Lendl\"},{\"name\":\"Bjorn\",\"surname\":\"Borg\"},{\"name\":\"John\",\"surname\":\"McEnroe\"},{\"name\":\"Jimmy\",\"surname\":\"Connors\"}]}\r\n"
    },
      "@version" => "1",
          "host" => {
        "hostname" => "andreas-MBP-2.station"
    },
          "tags" => [
        [0] "_jsonparsetoobigfailure"
    ],
       "message" => "{\"field_1\": [{\"name\":\"Jannik\",\"surname\":\"Sinner\"},{\"name\":\"Novak\",\"surname\":\"Djokovic\"},{\"name\":\"Rafa\",\"surname\":\"Nadal\"},{\"name\":\"Roger\",\"surname\":\"Federer\"},{\"name\":\"Pete\",\"surname\":\"Sampras\"},{\"name\":\"Andr\xC3\xA9\",\"surname\":\"Agassi\"},{\"name\":\"Rod\",\"surname\":\"Laver\"},{\"name\":\"Ivan\",\"surname\":\"Lendl\"},{\"name\":\"Bjorn\",\"surname\":\"Borg\"},{\"name\":\"John\",\"surname\":\"McEnroe\"},{\"name\":\"Jimmy\",\"surname\":\"Connors\"}],\"field_2\": [{\"name\":\"Jannik\",\"surname\":\"Sinner\"},{\"name\":\"Novak\",\"surname\":\"Djokovic\"},{\"name\":\"Rafa\",\"su"
}
[2024-09-02T14:45:51,966][INFO ][logstash.javapipeline    ][main] Pipeline terminated {"pipeline.id"=>"main"}
[2024-09-02T14:45:51,968][INFO ][logstash.agent           ] Pipelines running {:count=>0, :running_pipelines=>[], :non_running_pipelines=>[:main]}
[2024-09-02T14:45:51,970][INFO ][logstash.pipelinesregistry] Removed pipeline from registry successfully {:pipeline_id=>:main}
[2024-09-02T14:45:51,972][INFO ][logstash.runner          ] Logstash shut down.
```