### PR TITLE
fix typo deprecation message Megabytes MB instead of Mb

### DIFF
--- a/lib/logstash/codecs/json_lines.rb
+++ b/lib/logstash/codecs/json_lines.rb
@@ -58,7 +58,7 @@ class LogStash::Codecs::JSONLines < LogStash::Codecs::Base
 
   def register
     if original_params['decode_size_limit_bytes'].nil?
-      deprecation_logger.deprecated "The default value for `decode_size_limit_bytes`, currently at 512Mb, will be lowered in a future version to prevent Out of Memory errors from abnormally large messages or missing delimiters. Please set a value that reflects the largest expected message size (e.g. 20971520 for 20Mb)"
+      deprecation_logger.deprecated "The default value for `decode_size_limit_bytes`, currently at 512MB, will be lowered in a future version to prevent Out of Memory errors from abnormally large messages or missing delimiters. Please set a value that reflects the largest expected message size (e.g. 20971520 for 20MB)"
     end
     @buffer = FileWatch::BufferedTokenizer.new(@delimiter, @decode_size_limit_bytes)
     @converter = LogStash::Util::Charset.new(@charset)


### PR DESCRIPTION
`Mb` traditionally means Megabit though in context would be understood as Megaby, `MB` is mentioned in the documentation and less opened to interpretation for Megabytes

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
