### PR TITLE
Update test to be more flexible w/error message

### DIFF
--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -131,7 +131,7 @@ describe LogStash::Codecs::JSONLines, :ecs_compatibility_support do
       it "should raise an error if the max bytes are exceeded" do
         expect {
           subject.decode(maximum_payload << "z")
-        }.to raise_error(java.lang.IllegalStateException, "input buffer full")
+        }.to raise_error(java.lang.IllegalStateException, /input buffer full/)
       end
     end
 


### PR DESCRIPTION
This commit updates the expectation for the message when max bytes is exceeded to be more flexible. Instead of an exact match it expects a regex. This allows slight changes in the error message.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
