### PR TITLE
Fix tests using new buffered tokenizer change

### DIFF
--- a/spec/codecs/json_lines_spec.rb
+++ b/spec/codecs/json_lines_spec.rb
@@ -130,7 +130,7 @@ describe LogStash::Codecs::JSONLines, :ecs_compatibility_support do
       
       it "should raise an error if the max bytes are exceeded" do
         expect {
-          subject.decode(maximum_payload << "z")
+          subject.decode(maximum_payload + "z\n")
         }.to raise_error(java.lang.IllegalStateException, /input buffer full/)
       end
     end


### PR DESCRIPTION
Logstash's new buffered tokenizer behavior expects delimeters in order to trigger size checks. For a test that makes assertion about this behavior ensure a delimiter is present.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/


Closes https://github.com/logstash-plugins/logstash-codec-json_lines/issues/50